### PR TITLE
パイプが閉じられておらずResourceWarningが出る問題を修正

### DIFF
--- a/cshogi/usi/Engine.py
+++ b/cshogi/usi/Engine.py
@@ -135,4 +135,8 @@ class Engine:
         self.proc.stdin.write(cmd.encode('ascii') + b'\n')
         self.proc.stdin.flush()
         self.proc.wait()
+
+        self.proc.stdin.close()
+        self.proc.stdout.close()
+        self.proc.stderr.close()
         self.proc = None


### PR DESCRIPTION
# 概要
対局エンジンをquitで終了する際にResourceWarningが発生する現象を修正。

# 現象の発生
ユニットテストで検出された。
(標準のunittestではなくabsl-pyパッケージのabsl.testing.absltestを利用した。)

quitメソッドを呼び出した際に以下のメッセージが複数回出力された。
`ResourceWarning: Enable tracemalloc to get the object allocation traceback`

# 修正内容
起動時に開いた全てのチャネルを閉じる処理を追加。

# 結果
ResourceWarningが発生しなくなった。