### PR TITLE
開始日時に秒の情報が含まれないKIFファイルも読み込めるようにした

### DIFF
--- a/cshogi/KIF.py
+++ b/cshogi/KIF.py
@@ -159,7 +159,15 @@ class Parser:
                 (key, value) = line.split('：', 1)
                 value = value.rstrip('　')
                 if key == '開始日時':
-                    starttime = datetime.strptime(value, '%Y/%m/%d %H:%M:%S')
+                    try:
+                        starttime = datetime.strptime(value, '%Y/%m/%d %H:%M:%S')
+                    except ValueError:
+                        try:
+                            # if KIF file has not second information, try another parse
+                            starttime = datetime.strptime(value, '%Y/%m/%d %H:%M') 
+                        except ValueError:
+                            pass
+
                 if key == '先手' or key == '下手': # sente or shitate
                     # Blacks's name
                     names[cshogi.BLACK] = value


### PR DESCRIPTION
KIFファイルの使用では開始日時に年月日、時間:分:秒 となっているのが正しいようですが、
実際には分までの情報しか含まれていないKIFファイルもあるようです。

例: 
https://github.com/gunyarakun/python-shogi/blob/master/data/games/habu-fujii-2006.kif
http://live.shogi.or.jp/hakurei/kifu/1/hakurei202110160101.kif (live.shogi.or.jp においてある棋譜ファイルなど)

秒まで含めたパースが失敗したら、分までのパースをしてみる処理をしてみて、
更にそれでも駄目な場合は開始日時は無視するコードを追加しました。