### PR TITLE
pipインストール時に依存ライブラリがインストールされていなかった問題を修正

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,5 @@ setup(
         'License :: OSI Approved :: GNU General Public License (GPL)',
         "Operating System :: OS Independent",
     ],
+    install_requires=['flask', 'numpy', 'portpicker'],
 )


### PR DESCRIPTION
主な実行環境を Google Colab としているためか、pip インストール時に cshogi の依存するライブラリがインストールされていなかったため、修正しました。

厳密には、 `google.colab` もインポートされていますが
Colab でしか利用されず、Colab実行環境ではインストール済みのため、除外しています。

fixes #11