### PR TITLE
Add ".kif" extension to KIF parser

### DIFF
--- a/cshogi/KIF.py
+++ b/cshogi/KIF.py
@@ -93,7 +93,7 @@ class Parser:
         :raises KIF.ParserException: In the case of a parse error.
         """
         prefix, ext = os.path.splitext(path)
-        enc = 'utf-8' if ext == '.kifu' else 'cp932'
+        enc = 'utf-8' if ext in ['.kif', '.kifu'] else 'cp932'
         with codecs.open(path, 'r', enc) as f:
             return Parser.parse_str(f.read())
 


### PR DESCRIPTION
Many programs use ".kif" instead of ".kifu". Input files with extension ".kif" should also be parsed with utf-8.