### PR TITLE
ARM64対応

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,12 @@ class MyBuildExt(build_ext):
                 elif machine == "aarch64":
                     # ARM Linux
                     e.extra_compile_args.extend([
-                        "-march=armv8-a+simd",
+                        "-mcpu=generic",
+                    ])
+                elif machine == "arm64":
+                    # Apple Silicon
+                    e.extra_compile_args.extend([
+                        "-mcpu=apple-m1",
                     ])
         elif self.compiler.compiler_type == "msvc":
             for e in self.extensions:

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+import platform
 from setuptools import setup
 from Cython.Build import build_ext, cythonize
 from setuptools import Extension
@@ -6,15 +7,28 @@ from setuptools import Extension
 class MyBuildExt(build_ext):
     def build_extensions(self):
         if self.compiler.compiler_type == "unix":
+            machine = platform.machine().lower()
             for e in self.extensions:
                 e.extra_compile_args.extend(
                     [
                         "-std=c++17",
-                        "-msse4.2",
-                        "-mavx2",
                         "-Wno-enum-constexpr-conversion",
                     ]
                 )
+
+                if machine == "x86_64" or machine == "AMD64":
+                    # AMD64/x86_64
+                    e.extra_compile_args.extend(
+                        [
+                            "-msse4.2",
+                            "-mavx2",
+                        ]
+                    )
+                elif machine == "aarch64":
+                    # ARM Linux
+                    e.extra_compile_args.extend([
+                        "-march=armv8-a+simd",
+                    ])
         elif self.compiler.compiler_type == "msvc":
             for e in self.extensions:
                 e.extra_compile_args.extend(

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ class MyBuildExt(build_ext):
                     ]
                 )
 
-                if machine == "x86_64" or machine == "AMD64":
+                if machine == "x86_64" or machine == "amd64":
                     # AMD64/x86_64
                     e.extra_compile_args.extend(
                         [


### PR DESCRIPTION
ARM Mac及びARM Linux上で以下のエラーが出てcshogiのビルドに失敗していたため、ビルドできるように修正しました。
M4 MacBook Pro及びRaspberry Pi4上でビルドできることを確認しています。
```
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Collecting cshogi
  Downloading cshogi-0.9.7.tar.gz (495 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 495.7/495.7 kB 2.3 MB/s eta 0:00:00
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Requirement already satisfied: numpy in ./cshogi/.venv/lib/python3.11/site-packages (from cshogi) (2.3.5)
Building wheels for collected packages: cshogi
  Building wheel for cshogi (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for cshogi (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [41 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/elo.py -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/KI2.py -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/cli.py -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/KIF.py -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/CSA.py -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/PGN.py -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/__init__.py -> build/lib.linux-aarch64-cpython-311/cshogi
      creating build/lib.linux-aarch64-cpython-311/cshogi/dlshogi
      copying cshogi/dlshogi/__init__.py -> build/lib.linux-aarch64-cpython-311/cshogi/dlshogi
      creating build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi
      copying cshogi/gym_shogi/__init__.py -> build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi
      creating build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi/envs
      copying cshogi/gym_shogi/envs/__init__.py -> build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi/envs
      creating build/lib.linux-aarch64-cpython-311/cshogi/usi
      copying cshogi/usi/Engine.py -> build/lib.linux-aarch64-cpython-311/cshogi/usi
      copying cshogi/usi/__init__.py -> build/lib.linux-aarch64-cpython-311/cshogi/usi
      creating build/lib.linux-aarch64-cpython-311/cshogi/web
      copying cshogi/web/app.py -> build/lib.linux-aarch64-cpython-311/cshogi/web
      copying cshogi/web/__init__.py -> build/lib.linux-aarch64-cpython-311/cshogi/web
      copying cshogi/_cshogi.pyx -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/_cshogi.cpp -> build/lib.linux-aarch64-cpython-311/cshogi
      copying cshogi/gym_shogi/envs/shogi_env.cpp -> build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi/envs
      copying cshogi/gym_shogi/envs/shogi_env.pyx -> build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi/envs
      copying cshogi/gym_shogi/envs/shogi_vec_env.pyx -> build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi/envs
      copying cshogi/gym_shogi/envs/shogi_vec_env.cpp -> build/lib.linux-aarch64-cpython-311/cshogi/gym_shogi/envs
      creating build/lib.linux-aarch64-cpython-311/cshogi/web/static
      copying cshogi/web/static/board.js -> build/lib.linux-aarch64-cpython-311/cshogi/web/static
      creating build/lib.linux-aarch64-cpython-311/cshogi/web/templates
      copying cshogi/web/templates/board.html -> build/lib.linux-aarch64-cpython-311/cshogi/web/templates
      running build_ext
      building 'cshogi._cshogi' extension
      creating build/temp.linux-aarch64-cpython-311/cshogi
      creating build/temp.linux-aarch64-cpython-311/src
      aarch64-linux-gnu-g++ -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -DHAVE_SSE4 -DHAVE_SSE42 -DHAVE_AVX2 -Isrc -I/home/jj1guj/cshogi/.venv/include -I/usr/include/python3.11 -I/tmp/pip-build-env-ispqng0o/overlay/lib/python3.11/site-packages/numpy/_core/include -c cshogi/_cshogi.cpp -o build/temp.linux-aarch64-cpython-311/cshogi/_cshogi.o -std=c++17 -msse4.2 -mavx2 -Wno-enum-constexpr-conversion
      aarch64-linux-gnu-g++: error: unrecognized command-line option ‘-msse4.2’
      aarch64-linux-gnu-g++: error: unrecognized command-line option ‘-mavx2’
      error: command '/usr/bin/aarch64-linux-gnu-g++' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for cshogi
Failed to build cshogi
ERROR: Could not build wheels for cshogi, which is required to install pyproject.toml-based projects
```